### PR TITLE
Add tests and functionality for SettingsEditorPresenter to handle set…

### DIFF
--- a/src/TimeInWords/Presenters/SettingsEditorPresenter.cs
+++ b/src/TimeInWords/Presenters/SettingsEditorPresenter.cs
@@ -10,22 +10,34 @@ public class SettingsEditorPresenter
 {
     private readonly JsonSerializerOptions _jsonSerializerOptions = new() { WriteIndented = true };
 
+    private readonly string _filePath;
+
     public SettingsEditorPresenter(ISettingsEditorView settingsView, CancellationTokenSource mainLoopCts)
+        : this(settingsView, mainLoopCts, Path.Combine(AppContext.BaseDirectory, "appsettings.json")) { }
+
+    public SettingsEditorPresenter(
+        ISettingsEditorView settingsView,
+        CancellationTokenSource mainLoopCts,
+        string filePath
+    )
     {
+        _filePath = filePath;
         settingsView.Closed += (sender, args) => mainLoopCts.Cancel();
         settingsView.Saved += (sender, settings) => SaveSettings(settings);
 
-        using var fileStream = File.OpenRead(GetFilePath());
-        var settings = JsonSerializer.Deserialize<TimeInWordsSettings>(fileStream, _jsonSerializerOptions);
+        TimeInWordsSettings? settings = null;
+        if (File.Exists(_filePath))
+        {
+            using var fileStream = File.OpenRead(_filePath);
+            settings = JsonSerializer.Deserialize<TimeInWordsSettings>(fileStream, _jsonSerializerOptions);
+        }
 
         settingsView.Show(settings ?? new TimeInWordsSettings());
     }
 
     private void SaveSettings(TimeInWordsSettings settings)
     {
-        using var fileStream = File.Create(GetFilePath());
+        using var fileStream = File.Create(_filePath);
         JsonSerializer.Serialize(fileStream, settings, _jsonSerializerOptions);
     }
-
-    private static string GetFilePath() => Path.Combine(AppContext.BaseDirectory, "appsettings.json");
 }

--- a/tests/TimeInWords.Tests/Presenters/SettingsEditorPresenterShould.cs
+++ b/tests/TimeInWords.Tests/Presenters/SettingsEditorPresenterShould.cs
@@ -1,0 +1,61 @@
+﻿using TimeInWords.Presenters;
+using TimeInWords.Views;
+using TimeToTextLib;
+
+namespace TimeInWords.Tests.Presenters;
+
+public class SettingsEditorPresenterShould
+{
+    [Fact]
+    public void ReadSettingsFileAndPassToView()
+    {
+        var view = Substitute.For<ISettingsEditorView>();
+        var dutchSettingsFilePath = Path.Combine(AppContext.BaseDirectory, "./TestData/Settings_Dutch.json");
+
+        _ = new SettingsEditorPresenter(view, new CancellationTokenSource(), dutchSettingsFilePath);
+
+        view.Received(1).Show(Arg.Is<TimeInWordsSettings>(s => s.Language == LanguagePreset.Language.Dutch));
+    }
+
+    [Fact]
+    public void UseDefaultSettingsWhenFileDoesNotExist()
+    {
+        var view = Substitute.For<ISettingsEditorView>();
+        var missingSettingsFilePath = Path.Combine(
+            AppContext.BaseDirectory,
+            "./TestData/this_file_does_not_exist.json"
+        );
+
+        _ = new SettingsEditorPresenter(view, new CancellationTokenSource(), missingSettingsFilePath);
+
+        TimeInWordsSettings expectedSettings = new();
+        view.Received(1)
+            .Show(
+                Arg.Is<TimeInWordsSettings>(s =>
+                    s.Language == expectedSettings.Language
+                    && s.BackgroundColour == expectedSettings.BackgroundColour
+                    && s.ActiveFontColour == expectedSettings.ActiveFontColour
+                    && s.InactiveFontColour == expectedSettings.InactiveFontColour
+                    && s.Debug == expectedSettings.Debug
+                )
+            );
+    }
+
+    [Fact]
+    public void SaveSettingsToFile()
+    {
+        var view = Substitute.For<ISettingsEditorView>();
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test_{Guid.NewGuid()}.json");
+        _ = new SettingsEditorPresenter(view, new CancellationTokenSource(), tempFile);
+
+        var settingsFrench = new TimeInWordsSettings { Language = LanguagePreset.Language.French };
+        view.Saved += Raise.Event<EventHandler<TimeInWordsSettings>>(null, settingsFrench);
+
+        File.Exists(tempFile).Should().BeTrue();
+        var actualSettings = File.ReadAllText(tempFile);
+        var expectedSettings = File.ReadAllText(
+            Path.Combine(AppContext.BaseDirectory, "./TestData/Settings_French.json")
+        );
+        actualSettings.Should().Be(expectedSettings);
+    }
+}

--- a/tests/TimeInWords.Tests/TestData/Settings_Dutch.json
+++ b/tests/TimeInWords.Tests/TestData/Settings_Dutch.json
@@ -1,0 +1,3 @@
+﻿{
+  "Language": "Dutch"
+}

--- a/tests/TimeInWords.Tests/TestData/Settings_English.json
+++ b/tests/TimeInWords.Tests/TestData/Settings_English.json
@@ -1,0 +1,3 @@
+﻿{
+  "Language": "English"
+}

--- a/tests/TimeInWords.Tests/TestData/Settings_French.json
+++ b/tests/TimeInWords.Tests/TestData/Settings_French.json
@@ -1,0 +1,3 @@
+﻿{
+  "Language": "French"
+}

--- a/tests/TimeInWords.Tests/TimeInWords.Tests.csproj
+++ b/tests/TimeInWords.Tests/TimeInWords.Tests.csproj
@@ -36,4 +36,9 @@
       <SubType>Code</SubType>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <None Update="TestData\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
…tings file operations

- Introduced unit tests for SettingsEditorPresenter covering reading, default handling, and saving settings.
- Enhanced SettingsEditorPresenter to support customizable file paths for settings.
- Added JSON test files for English, Dutch, and French language settings.