### PR TITLE
Upgrade to Avalonia 12 and xUnit v3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,21 +5,20 @@
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.10" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Avalonia" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.1" />
+    <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 </Project>

--- a/src/DebugApp/App.axaml.cs
+++ b/src/DebugApp/App.axaml.cs
@@ -6,7 +6,14 @@ namespace DebugApp;
 
 public class App : Application
 {
-    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+
+#if DEBUG
+        this.AttachDeveloperTools();
+#endif
+    }
 
     public override void OnFrameworkInitializationCompleted()
     {

--- a/src/DebugApp/DebugApp.csproj
+++ b/src/DebugApp/DebugApp.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
+    <!--Condition below is needed to remove AvaloniaUI.DiagnosticsSupport package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TextToTimeGridLib\TextToTimeGridLib.csproj" />

--- a/src/DebugApp/MainWindow.axaml.cs
+++ b/src/DebugApp/MainWindow.axaml.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using System.Timers;
 using Avalonia.Controls;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
 using TextToTimeGridLib;

--- a/src/TimeInWords/App.axaml.cs
+++ b/src/TimeInWords/App.axaml.cs
@@ -5,5 +5,12 @@ namespace TimeInWords;
 
 public class App : Application
 {
-    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+
+#if DEBUG
+        this.AttachDeveloperTools();
+#endif
+    }
 }

--- a/src/TimeInWords/TimeInWords.csproj
+++ b/src/TimeInWords/TimeInWords.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
+    <!--Condition below is needed to remove AvaloniaUI.DiagnosticsSupport package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />

--- a/src/TimeInWords/Views/MainView.axaml.cs
+++ b/src/TimeInWords/Views/MainView.axaml.cs
@@ -93,14 +93,14 @@ public partial class MainView : Window, IMainView
             || mode == FullscreenMode.ForceFullscreen
         )
         {
-            SystemDecorations = SystemDecorations.None;
+            WindowDecorations = WindowDecorations.None;
             WindowState = WindowState.FullScreen;
             Topmost = true;
             Focus();
         }
         else
         {
-            SystemDecorations = SystemDecorations.Full;
+            WindowDecorations = WindowDecorations.Full;
             WindowState = WindowState.Normal;
             Topmost = false;
         }

--- a/tests/TextToTimeGridLib.Tests/TextToTimeGridLib.Tests.csproj
+++ b/tests/TextToTimeGridLib.Tests/TextToTimeGridLib.Tests.csproj
@@ -15,11 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/TextToTimeGridLib.Tests/TimeGridShould.cs
+++ b/tests/TextToTimeGridLib.Tests/TimeGridShould.cs
@@ -3,7 +3,6 @@ using System.Text;
 using TextToTimeGridLib.Grids;
 using TimeToTextLib;
 using TimeToTextLib.Presets;
-using Xunit.Abstractions;
 
 namespace TextToTimeGridLib.Tests;
 

--- a/tests/TimeInWords.Tests/TimeInWords.Tests.csproj
+++ b/tests/TimeInWords.Tests/TimeInWords.Tests.csproj
@@ -17,11 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/TimeInWords.Tests/Views/MainViewShould.cs
+++ b/tests/TimeInWords.Tests/Views/MainViewShould.cs
@@ -19,7 +19,7 @@ public class MainViewShould
 
         view.IsVisible.Should().BeTrue();
         view.ShowInTaskbar.Should().BeTrue();
-        view.SystemDecorations.Should().Be(SystemDecorations.Full);
+        view.WindowDecorations.Should().Be(WindowDecorations.Full);
         view.WindowState.Should().Be(WindowState.Normal);
         view.Topmost.Should().BeFalse();
     }
@@ -33,7 +33,7 @@ public class MainViewShould
 
         view.IsVisible.Should().BeTrue();
         view.ShowInTaskbar.Should().BeFalse();
-        view.SystemDecorations.Should().Be(SystemDecorations.None);
+        view.WindowDecorations.Should().Be(WindowDecorations.None);
         view.WindowState.Should().Be(WindowState.FullScreen);
         view.Topmost.Should().BeTrue();
     }

--- a/tests/TimeToTextLib.Tests/Presets/DutchPrecisePresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/DutchPrecisePresetShould.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
-using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/DutchPresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/DutchPresetShould.cs
@@ -1,7 +1,6 @@
 ﻿using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
-using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/EnglishPrecisePresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/EnglishPrecisePresetShould.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
-using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/EnglishPresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/EnglishPresetShould.cs
@@ -1,7 +1,6 @@
 ﻿using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
-using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/FrenchPrecisePresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/FrenchPrecisePresetShould.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
-using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/FrenchPresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/FrenchPresetShould.cs
@@ -1,7 +1,6 @@
 ﻿using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
-using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/GermanPrecisePresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/GermanPrecisePresetShould.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
-using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/GermanPresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/GermanPresetShould.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
-using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/SpanishPrecisePresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/SpanishPrecisePresetShould.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
-using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/SpanishPresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/SpanishPresetShould.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
-using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/TimeToTextLib.Tests.csproj
+++ b/tests/TimeToTextLib.Tests/TimeToTextLib.Tests.csproj
@@ -15,11 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

- **Avalonia 11.3 → 12.0.1**: Migrates to the new major version, adapting to breaking API changes (`SystemDecorations` → `WindowDecorations`, `Avalonia.Diagnostics` → `AvaloniaUI.DiagnosticsSupport`, new `AttachDeveloperTools()` initialization pattern).
- **xUnit v2 → v3**: Replaces the separate `xunit` + `xunit.runner.visualstudio` packages with the unified `xunit.v3` 3.2.2 package, removing the now-absent `Xunit.Abstractions` namespace from all test files.
- **Dependency bumps**: coverlet 6.0.4 → 8.0.1, AwesomeAssertions 9.3.0 → 9.4.0, Microsoft.Extensions.Configuration 10.0.1 → 10.0.5, Microsoft.NET.Test.Sdk 18.0.1 → 18.4.0.

## Test plan

- [ ] Verify `dotnet restore && dotnet build --no-restore` succeeds
- [ ] Verify `dotnet test` passes all tests across all three test projects
- [ ] Verify the app launches and renders correctly on desktop
- [ ] Verify developer tools attach in Debug builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)