### PR TITLE
Revert Avalonia 12 upgrade and update dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,20 +5,21 @@
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="12.0.1" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.1" />
-    <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.0" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.1" />
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.1" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
-    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Avalonia" Version="11.3.10" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.10" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.10" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.10" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.10" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.10" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,18 +5,18 @@
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.10" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.10" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Avalonia" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.14" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.14" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/src/DebugApp/App.axaml.cs
+++ b/src/DebugApp/App.axaml.cs
@@ -6,14 +6,7 @@ namespace DebugApp;
 
 public class App : Application
 {
-    public override void Initialize()
-    {
-        AvaloniaXamlLoader.Load(this);
-
-#if DEBUG
-        this.AttachDeveloperTools();
-#endif
-    }
+    public override void Initialize() => AvaloniaXamlLoader.Load(this);
 
     public override void OnFrameworkInitializationCompleted()
     {

--- a/src/DebugApp/DebugApp.csproj
+++ b/src/DebugApp/DebugApp.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
-    <!--Condition below is needed to remove AvaloniaUI.DiagnosticsSupport package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TextToTimeGridLib\TextToTimeGridLib.csproj" />

--- a/src/DebugApp/MainWindow.axaml.cs
+++ b/src/DebugApp/MainWindow.axaml.cs
@@ -2,7 +2,6 @@
 using System.Text;
 using System.Timers;
 using Avalonia.Controls;
-using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
 using TextToTimeGridLib;

--- a/src/TimeInWords/App.axaml.cs
+++ b/src/TimeInWords/App.axaml.cs
@@ -5,12 +5,5 @@ namespace TimeInWords;
 
 public class App : Application
 {
-    public override void Initialize()
-    {
-        AvaloniaXamlLoader.Load(this);
-
-#if DEBUG
-        this.AttachDeveloperTools();
-#endif
-    }
+    public override void Initialize() => AvaloniaXamlLoader.Load(this);
 }

--- a/src/TimeInWords/TimeInWords.csproj
+++ b/src/TimeInWords/TimeInWords.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
-    <!--Condition below is needed to remove AvaloniaUI.DiagnosticsSupport package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" />
+    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />

--- a/src/TimeInWords/Views/MainView.axaml.cs
+++ b/src/TimeInWords/Views/MainView.axaml.cs
@@ -93,14 +93,14 @@ public partial class MainView : Window, IMainView
             || mode == FullscreenMode.ForceFullscreen
         )
         {
-            WindowDecorations = WindowDecorations.None;
+            SystemDecorations = SystemDecorations.None;
             WindowState = WindowState.FullScreen;
             Topmost = true;
             Focus();
         }
         else
         {
-            WindowDecorations = WindowDecorations.Full;
+            SystemDecorations = SystemDecorations.Full;
             WindowState = WindowState.Normal;
             Topmost = false;
         }

--- a/tests/TextToTimeGridLib.Tests/TextToTimeGridLib.Tests.csproj
+++ b/tests/TextToTimeGridLib.Tests/TextToTimeGridLib.Tests.csproj
@@ -15,7 +15,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/TextToTimeGridLib.Tests/TimeGridShould.cs
+++ b/tests/TextToTimeGridLib.Tests/TimeGridShould.cs
@@ -3,6 +3,7 @@ using System.Text;
 using TextToTimeGridLib.Grids;
 using TimeToTextLib;
 using TimeToTextLib.Presets;
+using Xunit.Abstractions;
 
 namespace TextToTimeGridLib.Tests;
 

--- a/tests/TimeInWords.Tests/TimeInWords.Tests.csproj
+++ b/tests/TimeInWords.Tests/TimeInWords.Tests.csproj
@@ -17,7 +17,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/TimeInWords.Tests/Views/MainViewShould.cs
+++ b/tests/TimeInWords.Tests/Views/MainViewShould.cs
@@ -19,7 +19,7 @@ public class MainViewShould
 
         view.IsVisible.Should().BeTrue();
         view.ShowInTaskbar.Should().BeTrue();
-        view.WindowDecorations.Should().Be(WindowDecorations.Full);
+        view.SystemDecorations.Should().Be(SystemDecorations.Full);
         view.WindowState.Should().Be(WindowState.Normal);
         view.Topmost.Should().BeFalse();
     }
@@ -33,7 +33,7 @@ public class MainViewShould
 
         view.IsVisible.Should().BeTrue();
         view.ShowInTaskbar.Should().BeFalse();
-        view.WindowDecorations.Should().Be(WindowDecorations.None);
+        view.SystemDecorations.Should().Be(SystemDecorations.None);
         view.WindowState.Should().Be(WindowState.FullScreen);
         view.Topmost.Should().BeTrue();
     }

--- a/tests/TimeToTextLib.Tests/Presets/DutchPrecisePresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/DutchPrecisePresetShould.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
+using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/DutchPresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/DutchPresetShould.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
+using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/EnglishPrecisePresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/EnglishPrecisePresetShould.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
+using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/EnglishPresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/EnglishPresetShould.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
+using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/FrenchPrecisePresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/FrenchPrecisePresetShould.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
+using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/FrenchPresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/FrenchPresetShould.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
+using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/GermanPrecisePresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/GermanPrecisePresetShould.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
+using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/GermanPresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/GermanPresetShould.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
+using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/SpanishPrecisePresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/SpanishPrecisePresetShould.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
+using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/Presets/SpanishPresetShould.cs
+++ b/tests/TimeToTextLib.Tests/Presets/SpanishPresetShould.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using TimeToTextLib.Presets;
+using Xunit.Abstractions;
 
 namespace TimeToTextLib.Tests.Presets;
 

--- a/tests/TimeToTextLib.Tests/TimeToTextLib.Tests.csproj
+++ b/tests/TimeToTextLib.Tests/TimeToTextLib.Tests.csproj
@@ -15,7 +15,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

- Reverts the Avalonia 12 and xUnit v3 upgrade (#34) to restore stability on Avalonia 11.3.x and xUnit v2
- Updates all NuGet dependencies to their latest compatible versions: Avalonia 11.3.14, coverlet.collector 8.0.1, AwesomeAssertions 9.4.0, Microsoft.Extensions.Configuration 10.0.5, and Microsoft.NET.Test.Sdk 18.4.0

## Why

The Avalonia 12 upgrade introduced [issues](https://github.com/mikevanoo/TimeInWords/issues/35) that need more time to resolve. This PR rolls back to the proven Avalonia 11.3.x baseline while still picking up the latest patch releases for all dependencies.

## Test plan

- [ ] CI passes (build, test, coverage)
- [ ] Verify the app launches and displays the word clock correctly
- [ ] Confirm all language presets still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)