### PR TITLE
Tidy-ups across argument parsing, fades, matcher, and presets

### DIFF
--- a/src/TextToTimeGridLib/TimeGrid.cs
+++ b/src/TextToTimeGridLib/TimeGrid.cs
@@ -146,84 +146,48 @@ public abstract class TimeGrid
 
     private Bitmask GetBitmaskStrict(string input, bool[][] output)
     {
-        /*
-         * Strict mode finds whole words in the grid, respecting word boundaries.
-         * Example: "IT IS FIVE" will match letters that form complete words.
-         *
-         * The duplicate character handling (lines 160-163) handles cases where
-         * a word like "ELEVEN" appears in the grid but we're looking for "SEVEN".
-         * When we see "EL" but need "SE", we keep the 'L' as it might be the
-         * start of the next word.
-         */
+        var words = input.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var rows = CharGrid.Select(row => new string(row)).ToArray();
 
-        var wordIndex = 0;
-        var gridX = 0;
-        var gridY = 0;
-        var words = input.Split(' ');
-        var currentMatch = "";
+        var cursorRow = 0;
+        var cursorCol = 0;
 
-        foreach (var line in CharGrid)
+        foreach (var word in words)
         {
-            foreach (var cell in line)
+            var (row, col) = FindWordFrom(rows, word, cursorRow, cursorCol);
+            if (row < 0)
             {
-                if (wordIndex >= words.Length)
-                {
-                    break; // All words found
-                }
-
-                currentMatch += cell;
-                gridX++;
-
-                if (IsExactWordMatch(words[wordIndex], currentMatch))
-                {
-                    MarkWordAsActive(output, gridY, gridX, words[wordIndex].Length);
-                    currentMatch = "";
-                    wordIndex++;
-                }
-                else if (IsPartialWordMatch(words[wordIndex], currentMatch))
-                {
-                    // Continue building the current word
-                    continue;
-                }
-                else
-                {
-                    // Mismatch - reset but handle duplicate characters
-                    currentMatch = HandleDuplicateCharacters(currentMatch);
-                }
+                break;
             }
-            gridY++;
-            gridX = 0;
+
+            for (var c = col; c < col + word.Length; c++)
+            {
+                output[row][c] = true;
+            }
+
+            cursorRow = row;
+            cursorCol = col + word.Length;
         }
 
         return new Bitmask(output);
     }
 
-    private static bool IsExactWordMatch(string targetWord, string currentMatch) => targetWord == currentMatch;
-
-    private static bool IsPartialWordMatch(string targetWord, string currentMatch) =>
-        targetWord.StartsWith(currentMatch, StringComparison.InvariantCulture);
-
-    private static void MarkWordAsActive(bool[][] output, int y, int x, int wordLength)
+    private static (int row, int col) FindWordFrom(string[] rows, string word, int startRow, int startCol)
     {
-        var startX = x - wordLength;
-        var endX = x;
-
-        for (var xx = startX; xx < endX; xx++)
+        for (var row = startRow; row < rows.Length; row++)
         {
-            output[y][xx] = true;
-        }
-    }
+            var from = row == startRow ? startCol : 0;
+            if (from >= rows[row].Length)
+            {
+                continue;
+            }
 
-    private static string HandleDuplicateCharacters(string currentMatch)
-    {
-        // If we have 2 identical chars (like "EE"), keep the last one
-        // as it might be the start of the next word
-        // Example: Looking for "SEVEN" but found "EL" - keep the "L"
-        if (currentMatch.Length == 2 && currentMatch[0] == currentMatch[1])
-        {
-            return currentMatch[1].ToString();
+            var found = rows[row].IndexOf(word, from, StringComparison.Ordinal);
+            if (found >= 0)
+            {
+                return (row, found);
+            }
         }
-
-        return "";
+        return (-1, -1);
     }
 }

--- a/src/TimeInWords/Controls/ColorFader.cs
+++ b/src/TimeInWords/Controls/ColorFader.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Media;
 using Avalonia.Threading;
@@ -19,29 +20,40 @@ public class ColorFader
 
     private readonly IFadeableControl _control;
 
-    public static void SetControlForeColor(IFadeableControl control, Color toColor, int intervals = 20, int sleep = 20)
+    public static Task FadeForegroundAsync(
+        IFadeableControl control,
+        Color toColor,
+        int intervals = 20,
+        int stepDelayMs = 20,
+        CancellationToken cancellationToken = default
+    )
     {
-        var currentColor = (control.Foreground as SolidColorBrush)?.Color;
-        var colorFader = new ColorFader(control, currentColor, toColor, intervals);
-
-        Task.Run(async () =>
+        if (control.Foreground is not SolidColorBrush brush)
         {
-            await Task.Delay(sleep);
-            foreach (var color in colorFader.Fade())
+            return Task.CompletedTask;
+        }
+
+        var fader = new ColorFader(control, brush.Color, toColor, intervals);
+
+        return Dispatcher.UIThread.InvokeAsync(async () =>
+        {
+            try
             {
-                colorFader.SetControlForeColor(color);
-                await Task.Delay(sleep);
+                await Task.Delay(stepDelayMs, cancellationToken);
+                foreach (var color in fader.Fade())
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    fader._control.Foreground = new SolidColorBrush(color);
+                    await Task.Delay(stepDelayMs, cancellationToken);
+                }
             }
+            catch (OperationCanceledException) { }
         });
     }
 
-    private ColorFader(IFadeableControl control, Color? fromColor, Color toColor, int intervals)
+    private ColorFader(IFadeableControl control, Color fromColor, Color toColor, int intervals)
     {
-        if (!fromColor.HasValue)
-        {
-            throw new ArgumentNullException(nameof(fromColor));
-        }
-
         _control = control ?? throw new ArgumentNullException(nameof(control));
 
         if (intervals == 0)
@@ -49,7 +61,7 @@ public class ColorFader
             throw new ArgumentException($"{nameof(intervals)} must be a positive number");
         }
 
-        _fromColor = fromColor.Value;
+        _fromColor = fromColor;
         _toColor = toColor;
         _intervals = intervals;
 
@@ -70,7 +82,4 @@ public class ColorFader
         }
         yield return _toColor; // make sure we always return the exact target color last
     }
-
-    private void SetControlForeColor(Color color) =>
-        Dispatcher.UIThread.Post(() => _control.Foreground = new SolidColorBrush(color));
 }

--- a/src/TimeInWords/Controls/LedLetter.cs
+++ b/src/TimeInWords/Controls/LedLetter.cs
@@ -1,12 +1,19 @@
-﻿using System;
+﻿using System.Diagnostics.CodeAnalysis;
 using Avalonia.Controls;
+using Avalonia.LogicalTree;
 using Avalonia.Media;
 
 namespace TimeInWords.Controls;
 
+[SuppressMessage(
+    "Microsoft.Design",
+    "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable",
+    Justification = "Avalonia controls are not disposed by the framework; cleanup is performed in OnDetachedFromLogicalTree."
+)]
 internal class LedLetter : TextBlock, IFadeableControl
 {
     private readonly TimeInWordsSettings _settings;
+    private CancellationTokenSource? _fadeCts;
 
     public bool Active
     {
@@ -19,7 +26,11 @@ internal class LedLetter : TextBlock, IFadeableControl
 
                 field = value;
 
-                ColorFader.SetControlForeColor(this, endColor);
+                // Handle fading overlaps by cancelling the current one
+                _fadeCts?.Cancel();
+                _fadeCts?.Dispose();
+                _fadeCts = new CancellationTokenSource();
+                _ = ColorFader.FadeForegroundAsync(this, endColor, cancellationToken: _fadeCts.Token);
             }
         }
     }
@@ -34,5 +45,14 @@ internal class LedLetter : TextBlock, IFadeableControl
         Text = text;
         Foreground = new SolidColorBrush(_settings.InactiveFontColour);
         Background = new SolidColorBrush(_settings.BackgroundColour);
+    }
+
+    protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
+    {
+        // Handle active fading by cancelling
+        _fadeCts?.Cancel();
+        _fadeCts?.Dispose();
+        _fadeCts = null;
+        base.OnDetachedFromLogicalTree(e);
     }
 }

--- a/src/TimeInWords/Program.cs
+++ b/src/TimeInWords/Program.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Diagnostics;
-using System.IO;
-using System.Threading;
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Microsoft.Extensions.Configuration;
 using TimeInWords.Presenters;
@@ -24,52 +20,53 @@ internal static class Program
         BuildAvaloniaApp().Start(AppMain, args);
     }
 
-    // Application entry point. Avalonia is completely initialized.
+    // Avalonia configuration, don't remove; also used by visual designer.
+    public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<App>().UsePlatformDetect().WithInterFont(); //.LogToTrace(Avalonia.Logging.LogEventLevel.Information);
 
+    // Application entry point. Avalonia is completely initialized.
     private static void AppMain(Application app, string[] args)
     {
-        // A cancellation token source that will be used to stop the main loop
-        var cts = new CancellationTokenSource();
-
-        // Do your startup code here
-        var settings = ReadSettings();
-
-        if (args.Length > 0)
+        var mode = ParseStartupMode(args);
+        if (mode == StartupMode.Preview)
         {
-            var firstArgument = args[0].ToLowerInvariant().Trim().Substring(0, 2);
+            return;
+        }
 
-            switch (firstArgument)
-            {
-                case "/c":
-                    // Windows "Change Screensaver" dialog Settings mode
-                    var settingsView = new SettingsEditorView();
-                    _ = new SettingsEditorPresenter(settingsView, cts);
-                    app.Run(cts.Token);
-                    return;
-                case "/p":
-                    // Windows "Change Screensaver" dialog Preview mode
-                    // Ignore and exit
-                    return;
-                case "/s":
-                    settings.Debug = false;
-                    break;
-                default:
-                    settings.Debug = true;
-                    break;
-            }
+        var cts = new CancellationTokenSource();
+        var settings = ReadSettings();
+        settings.Debug = mode != StartupMode.Screensaver;
+
+        if (mode == StartupMode.Config)
+        {
+            var settingsView = new SettingsEditorView();
+            _ = new SettingsEditorPresenter(settingsView, cts);
         }
         else
         {
-            settings.Debug = true;
+            _ = new MainPresenter(settings, new MainViewFactory(), cts);
         }
 
-        // Start the main app
-        _ = new MainPresenter(settings, new MainViewFactory(), cts);
         app.Run(cts.Token);
     }
 
-    // Avalonia configuration, don't remove; also used by visual designer.
-    public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<App>().UsePlatformDetect().WithInterFont(); //.LogToTrace(Avalonia.Logging.LogEventLevel.Information);
+    private enum StartupMode
+    {
+        Debug,
+        Screensaver,
+        Config,
+        Preview,
+    }
+
+    private static StartupMode ParseStartupMode(string[] args) =>
+        args.Length == 0
+            ? StartupMode.Debug
+            : args[0].ToLowerInvariant() switch
+            {
+                ['/', 'c', ..] => StartupMode.Config, // Windows "Change Screensaver" dialog Settings mode
+                ['/', 'p', ..] => StartupMode.Preview, // Windows "Change Screensaver" dialog Preview mode. Ignore and exit
+                ['/', 's', ..] => StartupMode.Screensaver, // Full-screen mode
+                _ => StartupMode.Debug,
+            };
 
     private static TimeInWordsSettings ReadSettings()
     {

--- a/src/TimeInWords/Views/MainView.axaml.cs
+++ b/src/TimeInWords/Views/MainView.axaml.cs
@@ -139,8 +139,8 @@ public partial class MainView : Window, IMainView
         // Determines whether the mouse was moved and whether the movement was large.
         // if so, the screen saver is ended.
         if (
-            (_oldX > 0 & _oldY > 0)
-            & (Math.Abs(position.X - _oldX) > MovementThreshold | Math.Abs(position.Y - _oldY) > MovementThreshold)
+            (_oldX > 0 && _oldY > 0)
+            && (Math.Abs(position.X - _oldX) > MovementThreshold || Math.Abs(position.Y - _oldY) > MovementThreshold)
         )
         {
             if (IsFullScreen)

--- a/src/TimeToTextLib/Presets/DutchPrecisePreset.cs
+++ b/src/TimeToTextLib/Presets/DutchPrecisePreset.cs
@@ -1,51 +1,25 @@
-using System;
-using System.Globalization;
-using System.Text;
-
 namespace TimeToTextLib.Presets;
 
 public class DutchPrecisePreset : LanguagePreset
 {
     public override TimeToTextFormat Format(DateTime time)
     {
-        var s = new StringBuilder($"{Prefix} ");
         var hour = HourIn12HourClock(time.Hour);
         var minute = time.Minute;
 
-        if (minute == 0)
+        var phrase = minute switch
         {
-            s.Append(CultureInfo.InvariantCulture, $"{Hour(hour)} UUR");
-        }
-        else if (minute <= 14)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"{GetNumberText(minute)} OVER {Hour(hour)}");
-        }
-        else if (minute == 15)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"KWART OVER {Hour(hour)}");
-        }
-        else if (minute <= 29)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"{GetNumberText(30 - minute)} VOOR HALF {Hour(hour + 1)}");
-        }
-        else if (minute == 30)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"HALF {Hour(hour + 1)}");
-        }
-        else if (minute <= 44)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"{GetNumberText(minute - 30)} OVER HALF {Hour(hour + 1)}");
-        }
-        else if (minute == 45)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"KWART VOOR {Hour(hour + 1)}");
-        }
-        else
-        {
-            s.Append(CultureInfo.InvariantCulture, $"{GetNumberText(60 - minute)} VOOR {Hour(hour + 1)}");
-        }
+            0 => $"{Hour(hour)} UUR",
+            15 => $"KWART OVER {Hour(hour)}",
+            30 => $"HALF {Hour(hour + 1)}",
+            45 => $"KWART VOOR {Hour(hour + 1)}",
+            <= 14 => $"{GetNumberText(minute)} OVER {Hour(hour)}",
+            <= 29 => $"{GetNumberText(30 - minute)} VOOR HALF {Hour(hour + 1)}",
+            <= 44 => $"{GetNumberText(minute - 30)} OVER HALF {Hour(hour + 1)}",
+            _ => $"{GetNumberText(60 - minute)} VOOR {Hour(hour + 1)}",
+        };
 
-        return new TimeToTextFormat { TimeAsText = s.ToString(), AdditionalMinutes = 0 };
+        return new TimeToTextFormat { TimeAsText = $"{Prefix} {phrase}", AdditionalMinutes = 0 };
     }
 
     protected override string[] Numbers =>

--- a/src/TimeToTextLib/Presets/DutchPreset.cs
+++ b/src/TimeToTextLib/Presets/DutchPreset.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text;
 
 namespace TimeToTextLib.Presets;

--- a/src/TimeToTextLib/Presets/DutchPreset.cs
+++ b/src/TimeToTextLib/Presets/DutchPreset.cs
@@ -1,58 +1,30 @@
-﻿using System.Globalization;
-using System.Text;
-
-namespace TimeToTextLib.Presets;
+﻿namespace TimeToTextLib.Presets;
 
 public class DutchPreset : LanguagePreset
 {
     public override TimeToTextFormat Format(DateTime time)
     {
-        var s = new StringBuilder($"{Prefix} ");
         var hour = HourIn12HourClock(time.Hour);
         var minute = MinuteRoundedDown(time.Minute);
         var additionalMinutes = AdditionalMinutes(time.Minute);
 
-        switch (minute)
+        var phrase = minute switch
         {
-            case 0:
-                s.Append(CultureInfo.InvariantCulture, $"{Hour(hour)} UUR");
-                break;
-            case 5:
-                s.Append(CultureInfo.InvariantCulture, $"{GetNumberText(minute)} OVER {Hour(hour)}");
-                break;
-            case 10:
-                s.Append(CultureInfo.InvariantCulture, $"{GetNumberText(minute)} OVER {Hour(hour)}");
-                break;
-            case 15:
-                s.Append(CultureInfo.InvariantCulture, $"KWART OVER {Hour(hour)}");
-                break;
-            case 20:
-                s.Append(CultureInfo.InvariantCulture, $"{GetNumberText(10)} VOOR HALF {Hour(hour + 1)}");
-                break;
-            case 25:
-                s.Append(CultureInfo.InvariantCulture, $"{GetNumberText(5)} VOOR HALF {Hour(hour + 1)}");
-                break;
-            case 30:
-                s.Append(CultureInfo.InvariantCulture, $"HALF {Hour(hour)}");
-                break;
-            case 35:
-                s.Append(CultureInfo.InvariantCulture, $"{GetNumberText(5)} OVER HALF {Hour(hour + 1)}");
-                break;
-            case 40:
-                s.Append(CultureInfo.InvariantCulture, $"{GetNumberText(10)} OVER HALF {Hour(hour + 1)}");
-                break;
-            case 45:
-                s.Append(CultureInfo.InvariantCulture, $"KWART VOOR {Hour(hour + 1)}");
-                break;
-            case 50:
-                s.Append(CultureInfo.InvariantCulture, $"{GetNumberText(10)} VOOR {Hour(hour + 1)}");
-                break;
-            case 55:
-                s.Append(CultureInfo.InvariantCulture, $"{GetNumberText(5)} VOOR {Hour(hour + 1)}");
-                break;
-        }
+            0 => $"{Hour(hour)} UUR",
+            5 or 10 => $"{GetNumberText(minute)} OVER {Hour(hour)}",
+            15 => $"KWART OVER {Hour(hour)}",
+            20 => $"{GetNumberText(10)} VOOR HALF {Hour(hour + 1)}",
+            25 => $"{GetNumberText(5)} VOOR HALF {Hour(hour + 1)}",
+            30 => $"HALF {Hour(hour)}",
+            35 => $"{GetNumberText(5)} OVER HALF {Hour(hour + 1)}",
+            40 => $"{GetNumberText(10)} OVER HALF {Hour(hour + 1)}",
+            45 => $"KWART VOOR {Hour(hour + 1)}",
+            50 => $"{GetNumberText(10)} VOOR {Hour(hour + 1)}",
+            55 => $"{GetNumberText(5)} VOOR {Hour(hour + 1)}",
+            _ => throw new ArgumentOutOfRangeException(nameof(time)),
+        };
 
-        return new TimeToTextFormat() { TimeAsText = s.ToString(), AdditionalMinutes = additionalMinutes };
+        return new TimeToTextFormat { TimeAsText = $"{Prefix} {phrase}", AdditionalMinutes = additionalMinutes };
     }
 
     protected override string[] Numbers =>

--- a/src/TimeToTextLib/Presets/EnglishPrecisePreset.cs
+++ b/src/TimeToTextLib/Presets/EnglishPrecisePreset.cs
@@ -1,43 +1,23 @@
-using System;
-using System.Globalization;
-using System.Text;
-
 namespace TimeToTextLib.Presets;
 
 public class EnglishPrecisePreset : LanguagePreset
 {
     public override TimeToTextFormat Format(DateTime time)
     {
-        var s = new StringBuilder($"{Prefix} ");
         var hour = HourIn12HourClock(time.Hour);
         var minute = time.Minute;
 
-        if (minute == 0)
+        var phrase = minute switch
         {
-            s.Append(CultureInfo.InvariantCulture, $"{Hour(hour)} OCLOCK");
-        }
-        else if (minute == 15)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"A QUARTER PAST {Hour(hour)}");
-        }
-        else if (minute == 30)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"HALF PAST {Hour(hour)}");
-        }
-        else if (minute == 45)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"A QUARTER TO {Hour(hour + 1)}");
-        }
-        else if (minute <= 29)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"{GetNumberTextWithSuffix(minute)} PAST {Hour(hour)}");
-        }
-        else
-        {
-            s.Append(CultureInfo.InvariantCulture, $"{GetNumberTextWithSuffix(60 - minute)} TO {Hour(hour + 1)}");
-        }
+            0 => $"{Hour(hour)} OCLOCK",
+            15 => $"A QUARTER PAST {Hour(hour)}",
+            30 => $"HALF PAST {Hour(hour)}",
+            45 => $"A QUARTER TO {Hour(hour + 1)}",
+            <= 29 => $"{GetNumberTextWithSuffix(minute)} PAST {Hour(hour)}",
+            _ => $"{GetNumberTextWithSuffix(60 - minute)} TO {Hour(hour + 1)}",
+        };
 
-        return new TimeToTextFormat { TimeAsText = s.ToString(), AdditionalMinutes = 0 };
+        return new TimeToTextFormat { TimeAsText = $"{Prefix} {phrase}", AdditionalMinutes = 0 };
     }
 
     private string GetNumberTextWithSuffix(int number)

--- a/src/TimeToTextLib/Presets/EnglishPreset.cs
+++ b/src/TimeToTextLib/Presets/EnglishPreset.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text;
 
 namespace TimeToTextLib.Presets;

--- a/src/TimeToTextLib/Presets/EnglishPreset.cs
+++ b/src/TimeToTextLib/Presets/EnglishPreset.cs
@@ -1,58 +1,30 @@
-﻿using System.Globalization;
-using System.Text;
-
-namespace TimeToTextLib.Presets;
+﻿namespace TimeToTextLib.Presets;
 
 public class EnglishPreset : LanguagePreset
 {
     public override TimeToTextFormat Format(DateTime time)
     {
-        var s = new StringBuilder($"{Prefix} ");
         var hour = HourIn12HourClock(time.Hour);
         var minute = MinuteRoundedDown(time.Minute);
         var additionalMinutes = AdditionalMinutes(time.Minute);
 
-        switch (minute)
+        var phrase = minute switch
         {
-            case 0:
-                s.Append(CultureInfo.InvariantCulture, $"{Hour(hour)} OCLOCK");
-                break;
-            case 5:
-                s.Append(CultureInfo.InvariantCulture, $"{GetNumberText(minute)} PAST {Hour(hour)}");
-                break;
-            case 10:
-                s.Append(CultureInfo.InvariantCulture, $"{GetNumberText(minute)} PAST {Hour(hour)}");
-                break;
-            case 15:
-                s.Append(CultureInfo.InvariantCulture, $"A QUARTER PAST {Hour(hour)}");
-                break;
-            case 20:
-                s.Append(CultureInfo.InvariantCulture, $"TWENTY PAST {Hour(hour)}");
-                break;
-            case 25:
-                s.Append(CultureInfo.InvariantCulture, $"TWENTYFIVE PAST {Hour(hour)}");
-                break;
-            case 30:
-                s.Append(CultureInfo.InvariantCulture, $"HALF PAST {Hour(hour)}");
-                break;
-            case 35:
-                s.Append(CultureInfo.InvariantCulture, $"TWENTYFIVE TO {Hour(hour + 1)}");
-                break;
-            case 40:
-                s.Append(CultureInfo.InvariantCulture, $"TWENTY TO {Hour(hour + 1)}");
-                break;
-            case 45:
-                s.Append(CultureInfo.InvariantCulture, $"A QUARTER TO {Hour(hour + 1)}");
-                break;
-            case 50:
-                s.Append(CultureInfo.InvariantCulture, $"TEN TO {Hour(hour + 1)}");
-                break;
-            case 55:
-                s.Append(CultureInfo.InvariantCulture, $"FIVE TO {Hour(hour + 1)}");
-                break;
-        }
+            0 => $"{Hour(hour)} OCLOCK",
+            5 or 10 => $"{GetNumberText(minute)} PAST {Hour(hour)}",
+            15 => $"A QUARTER PAST {Hour(hour)}",
+            20 => $"TWENTY PAST {Hour(hour)}",
+            25 => $"TWENTYFIVE PAST {Hour(hour)}",
+            30 => $"HALF PAST {Hour(hour)}",
+            35 => $"TWENTYFIVE TO {Hour(hour + 1)}",
+            40 => $"TWENTY TO {Hour(hour + 1)}",
+            45 => $"A QUARTER TO {Hour(hour + 1)}",
+            50 => $"TEN TO {Hour(hour + 1)}",
+            55 => $"FIVE TO {Hour(hour + 1)}",
+            _ => throw new ArgumentOutOfRangeException(nameof(time)),
+        };
 
-        return new TimeToTextFormat() { TimeAsText = s.ToString(), AdditionalMinutes = additionalMinutes };
+        return new TimeToTextFormat { TimeAsText = $"{Prefix} {phrase}", AdditionalMinutes = additionalMinutes };
     }
 
     protected override string[] Numbers =>

--- a/src/TimeToTextLib/Presets/FrenchPrecisePreset.cs
+++ b/src/TimeToTextLib/Presets/FrenchPrecisePreset.cs
@@ -1,45 +1,22 @@
-using System;
-using System.Globalization;
-using System.Text;
-
 namespace TimeToTextLib.Presets;
 
 public class FrenchPrecisePreset : LanguagePreset
 {
     public override TimeToTextFormat Format(DateTime time)
     {
-        var s = new StringBuilder($"{Prefix} ");
         var minute = time.Minute;
 
-        if (minute == 0)
+        var phrase = minute switch
         {
-            s.Append(HourWithHeures(time.Hour));
-        }
-        else if (minute == 15)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour)} ET QUART");
-        }
-        else if (minute == 30)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour)} ET {Demie(time.Hour)}");
-        }
-        else if (minute == 45)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour + 1)} MOINS LE QUART");
-        }
-        else if (minute <= 29)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour)} {GetNumberText(minute)}");
-        }
-        else
-        {
-            s.Append(
-                CultureInfo.InvariantCulture,
-                $"{HourWithHeures(time.Hour + 1)} MOINS {GetNumberText(60 - minute)}"
-            );
-        }
+            0 => HourWithHeures(time.Hour),
+            15 => $"{HourWithHeures(time.Hour)} ET QUART",
+            30 => $"{HourWithHeures(time.Hour)} ET {Demie(time.Hour)}",
+            45 => $"{HourWithHeures(time.Hour + 1)} MOINS LE QUART",
+            <= 29 => $"{HourWithHeures(time.Hour)} {GetNumberText(minute)}",
+            _ => $"{HourWithHeures(time.Hour + 1)} MOINS {GetNumberText(60 - minute)}",
+        };
 
-        return new TimeToTextFormat { TimeAsText = s.ToString(), AdditionalMinutes = 0 };
+        return new TimeToTextFormat { TimeAsText = $"{Prefix} {phrase}", AdditionalMinutes = 0 };
     }
 
     protected override string[] Numbers =>

--- a/src/TimeToTextLib/Presets/FrenchPreset.cs
+++ b/src/TimeToTextLib/Presets/FrenchPreset.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text;
 
 namespace TimeToTextLib.Presets;

--- a/src/TimeToTextLib/Presets/FrenchPreset.cs
+++ b/src/TimeToTextLib/Presets/FrenchPreset.cs
@@ -1,57 +1,30 @@
-﻿using System.Globalization;
-using System.Text;
-
-namespace TimeToTextLib.Presets;
+﻿namespace TimeToTextLib.Presets;
 
 public class FrenchPreset : LanguagePreset
 {
     public override TimeToTextFormat Format(DateTime time)
     {
-        var s = new StringBuilder($"{Prefix} ");
         var minute = MinuteRoundedDown(time.Minute);
         var additionalMinutes = AdditionalMinutes(time.Minute);
 
-        switch (minute)
+        var phrase = minute switch
         {
-            case 0:
-                s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour)}");
-                break;
-            case 5:
-                s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour)} {Numbers[4]}");
-                break;
-            case 10:
-                s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour)} {Numbers[9]}");
-                break;
-            case 15:
-                s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour)} ET QUART");
-                break;
-            case 20:
-                s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour)} VINGT");
-                break;
-            case 25:
-                s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour)} VINGT-CINQ");
-                break;
-            case 30:
-                s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour)} ET DEMIE");
-                break;
-            case 35:
-                s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour + 1)} MOINS VINGT-CINQ");
-                break;
-            case 40:
-                s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour + 1)} MOINS VINGT");
-                break;
-            case 45:
-                s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour + 1)} MOINS LE QUART");
-                break;
-            case 50:
-                s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour + 1)} MOINS DIX");
-                break;
-            case 55:
-                s.Append(CultureInfo.InvariantCulture, $"{HourWithHeures(time.Hour + 1)} MOINS CINQ");
-                break;
-        }
+            0 => HourWithHeures(time.Hour),
+            5 => $"{HourWithHeures(time.Hour)} {Numbers[4]}",
+            10 => $"{HourWithHeures(time.Hour)} {Numbers[9]}",
+            15 => $"{HourWithHeures(time.Hour)} ET QUART",
+            20 => $"{HourWithHeures(time.Hour)} VINGT",
+            25 => $"{HourWithHeures(time.Hour)} VINGT-CINQ",
+            30 => $"{HourWithHeures(time.Hour)} ET DEMIE",
+            35 => $"{HourWithHeures(time.Hour + 1)} MOINS VINGT-CINQ",
+            40 => $"{HourWithHeures(time.Hour + 1)} MOINS VINGT",
+            45 => $"{HourWithHeures(time.Hour + 1)} MOINS LE QUART",
+            50 => $"{HourWithHeures(time.Hour + 1)} MOINS DIX",
+            55 => $"{HourWithHeures(time.Hour + 1)} MOINS CINQ",
+            _ => throw new ArgumentOutOfRangeException(nameof(time)),
+        };
 
-        return new TimeToTextFormat() { TimeAsText = s.ToString(), AdditionalMinutes = additionalMinutes };
+        return new TimeToTextFormat { TimeAsText = $"{Prefix} {phrase}", AdditionalMinutes = additionalMinutes };
     }
 
     protected override string[] Numbers =>

--- a/src/TimeToTextLib/Presets/GermanPrecisePreset.cs
+++ b/src/TimeToTextLib/Presets/GermanPrecisePreset.cs
@@ -1,75 +1,54 @@
-using System;
-using System.Globalization;
-using System.Text;
-
 namespace TimeToTextLib.Presets;
 
 public class GermanPrecisePreset : LanguagePreset
 {
     public override TimeToTextFormat Format(DateTime time)
     {
-        var s = new StringBuilder($"{Prefix} ");
         var hour = HourIn12HourClock(time.Hour);
         var minute = time.Minute;
 
-        if (minute == 0)
+        var phrase = minute switch
         {
-            s.Append(CultureInfo.InvariantCulture, $"{HourForUhr(hour)} UHR");
-        }
-        else if (minute <= 14)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"{MinuteNumber(minute)} {MinuteWord(minute)} NACH {Hour(hour)}");
-        }
-        else if (minute == 15)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"VIERTEL NACH {Hour(hour)}");
-        }
-        else if (minute <= 29)
-        {
-            var diff = 30 - minute;
-            s.Append(CultureInfo.InvariantCulture,
-                $"{MinuteNumber(diff)} {MinuteWord(diff)} VOR HALB {Hour(hour + 1)}");
-        }
-        else if (minute == 30)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"HALB {Hour(hour + 1)}");
-        }
-        else if (minute <= 44)
-        {
-            var diff = minute - 30;
-            s.Append(CultureInfo.InvariantCulture,
-                $"{MinuteNumber(diff)} {MinuteWord(diff)} NACH HALB {Hour(hour + 1)}");
-        }
-        else if (minute == 45)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"VIERTEL VOR {Hour(hour + 1)}");
-        }
-        else
-        {
-            var diff = 60 - minute;
-            s.Append(CultureInfo.InvariantCulture,
-                $"{MinuteNumber(diff)} {MinuteWord(diff)} VOR {Hour(hour + 1)}");
-        }
+            0 => $"{HourForUhr(hour)} UHR",
+            15 => $"VIERTEL NACH {Hour(hour)}",
+            30 => $"HALB {Hour(hour + 1)}",
+            45 => $"VIERTEL VOR {Hour(hour + 1)}",
+            <= 14 => $"{MinutesPhrase(minute)} NACH {Hour(hour)}",
+            <= 29 => $"{MinutesPhrase(30 - minute)} VOR HALB {Hour(hour + 1)}",
+            <= 44 => $"{MinutesPhrase(minute - 30)} NACH HALB {Hour(hour + 1)}",
+            _ => $"{MinutesPhrase(60 - minute)} VOR {Hour(hour + 1)}",
+        };
 
-        return new TimeToTextFormat { TimeAsText = s.ToString(), AdditionalMinutes = 0 };
+        return new TimeToTextFormat { TimeAsText = $"{Prefix} {phrase}", AdditionalMinutes = 0 };
     }
 
-    private string HourForUhr(int hour) =>
-        hour == 1 ? "EIN" : Hour(hour);
+    private string HourForUhr(int hour) => hour == 1 ? "EIN" : Hour(hour);
 
-    private static string MinuteWord(int minutes) =>
-        minutes == 1 ? "MINUTE" : "MINUTEN";
+    private string MinutesPhrase(int minutes) => $"{MinuteNumber(minutes)} {MinuteWord(minutes)}";
 
-    private string MinuteNumber(int minutes) =>
-        minutes == 1 ? "EINE" : GetMinuteNumberText(minutes);
+    private static string MinuteWord(int minutes) => minutes == 1 ? "MINUTE" : "MINUTEN";
+
+    private string MinuteNumber(int minutes) => minutes == 1 ? "EINE" : GetMinuteNumberText(minutes);
 
     private string GetMinuteNumberText(int minutes) =>
         minutes >= 21 ? $"{GetNumberText(minutes - 20)} UND ZWANZIG" : GetNumberText(minutes);
 
     protected override string[] Numbers =>
         [
-            "EINS", "ZWEI", "DREI", "VIER", "FÜNF", "SECHS", "SIEBEN", "ACHT", "NEUN", "ZEHN",
-            "ELF", "ZWÖLF", "DREIZEHN", "VIERZEHN",
+            "EINS",
+            "ZWEI",
+            "DREI",
+            "VIER",
+            "FÜNF",
+            "SECHS",
+            "SIEBEN",
+            "ACHT",
+            "NEUN",
+            "ZEHN",
+            "ELF",
+            "ZWÖLF",
+            "DREIZEHN",
+            "VIERZEHN",
         ];
 
     protected override string Prefix => "ES IST";

--- a/src/TimeToTextLib/Presets/GermanPreset.cs
+++ b/src/TimeToTextLib/Presets/GermanPreset.cs
@@ -1,58 +1,31 @@
-using System.Globalization;
-using System.Text;
-
 namespace TimeToTextLib.Presets;
 
 public class GermanPreset : LanguagePreset
 {
     public override TimeToTextFormat Format(DateTime time)
     {
-        var s = new StringBuilder($"{Prefix} ");
         var hour = HourIn12HourClock(time.Hour);
         var minute = MinuteRoundedDown(time.Minute);
         var additionalMinutes = AdditionalMinutes(time.Minute);
 
-        switch (minute)
+        var phrase = minute switch
         {
-            case 0:
-                s.Append(CultureInfo.InvariantCulture, $"{HourForUhr(hour)} UHR");
-                break;
-            case 5:
-                s.Append(CultureInfo.InvariantCulture, $"FÜNF NACH {Hour(hour)}");
-                break;
-            case 10:
-                s.Append(CultureInfo.InvariantCulture, $"ZEHN NACH {Hour(hour)}");
-                break;
-            case 15:
-                s.Append(CultureInfo.InvariantCulture, $"VIERTEL NACH {Hour(hour)}");
-                break;
-            case 20:
-                s.Append(CultureInfo.InvariantCulture, $"ZWANZIG NACH {Hour(hour)}");
-                break;
-            case 25:
-                s.Append(CultureInfo.InvariantCulture, $"FÜNF VOR HALB {Hour(hour + 1)}");
-                break;
-            case 30:
-                s.Append(CultureInfo.InvariantCulture, $"HALB {Hour(hour + 1)}");
-                break;
-            case 35:
-                s.Append(CultureInfo.InvariantCulture, $"FÜNF NACH HALB {Hour(hour + 1)}");
-                break;
-            case 40:
-                s.Append(CultureInfo.InvariantCulture, $"ZWANZIG VOR {Hour(hour + 1)}");
-                break;
-            case 45:
-                s.Append(CultureInfo.InvariantCulture, $"VIERTEL VOR {Hour(hour + 1)}");
-                break;
-            case 50:
-                s.Append(CultureInfo.InvariantCulture, $"ZEHN VOR {Hour(hour + 1)}");
-                break;
-            case 55:
-                s.Append(CultureInfo.InvariantCulture, $"FÜNF VOR {Hour(hour + 1)}");
-                break;
-        }
+            0 => $"{HourForUhr(hour)} UHR",
+            5 => $"FÜNF NACH {Hour(hour)}",
+            10 => $"ZEHN NACH {Hour(hour)}",
+            15 => $"VIERTEL NACH {Hour(hour)}",
+            20 => $"ZWANZIG NACH {Hour(hour)}",
+            25 => $"FÜNF VOR HALB {Hour(hour + 1)}",
+            30 => $"HALB {Hour(hour + 1)}",
+            35 => $"FÜNF NACH HALB {Hour(hour + 1)}",
+            40 => $"ZWANZIG VOR {Hour(hour + 1)}",
+            45 => $"VIERTEL VOR {Hour(hour + 1)}",
+            50 => $"ZEHN VOR {Hour(hour + 1)}",
+            55 => $"FÜNF VOR {Hour(hour + 1)}",
+            _ => throw new ArgumentOutOfRangeException(nameof(time)),
+        };
 
-        return new TimeToTextFormat { TimeAsText = s.ToString(), AdditionalMinutes = additionalMinutes };
+        return new TimeToTextFormat { TimeAsText = $"{Prefix} {phrase}", AdditionalMinutes = additionalMinutes };
     }
 
     private string HourForUhr(int hour) => hour == 1 ? "EIN" : Hour(hour);

--- a/src/TimeToTextLib/Presets/GermanPreset.cs
+++ b/src/TimeToTextLib/Presets/GermanPreset.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Globalization;
 using System.Text;
 
@@ -56,8 +55,7 @@ public class GermanPreset : LanguagePreset
         return new TimeToTextFormat { TimeAsText = s.ToString(), AdditionalMinutes = additionalMinutes };
     }
 
-    private string HourForUhr(int hour) =>
-        hour == 1 ? "EIN" : Hour(hour);
+    private string HourForUhr(int hour) => hour == 1 ? "EIN" : Hour(hour);
 
     protected override string[] Numbers =>
         ["EINS", "ZWEI", "DREI", "VIER", "FÜNF", "SECHS", "SIEBEN", "ACHT", "NEUN", "ZEHN", "ELF", "ZWÖLF"];

--- a/src/TimeToTextLib/Presets/SpanishPrecisePreset.cs
+++ b/src/TimeToTextLib/Presets/SpanishPrecisePreset.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Globalization;
-using System.Text;
-
 namespace TimeToTextLib.Presets;
 
 public class SpanishPrecisePreset : LanguagePreset
@@ -12,22 +8,14 @@ public class SpanishPrecisePreset : LanguagePreset
         var minute = time.Minute;
         var hourForPrefix = minute >= 31 ? hour + 1 : hour;
 
-        var s = new StringBuilder($"{PrefixForHour(hourForPrefix)} ");
+        var phrase = minute switch
+        {
+            0 => $"{Hour(hour)} EN PUNTO",
+            <= 30 => $"{Hour(hour)} Y {GetMinuteText(minute)}",
+            _ => $"{Hour(hour + 1)} MENOS {GetMinuteText(60 - minute)}",
+        };
 
-        if (minute == 0)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"{Hour(hour)} EN PUNTO");
-        }
-        else if (minute <= 30)
-        {
-            s.Append(CultureInfo.InvariantCulture, $"{Hour(hour)} Y {GetMinuteText(minute)}");
-        }
-        else
-        {
-            s.Append(CultureInfo.InvariantCulture, $"{Hour(hour + 1)} MENOS {GetMinuteText(60 - minute)}");
-        }
-
-        return new TimeToTextFormat { TimeAsText = s.ToString(), AdditionalMinutes = 0 };
+        return new TimeToTextFormat { TimeAsText = $"{PrefixForHour(hourForPrefix)} {phrase}", AdditionalMinutes = 0 };
     }
 
     private string GetMinuteText(int minutes)

--- a/src/TimeToTextLib/Presets/SpanishPreset.cs
+++ b/src/TimeToTextLib/Presets/SpanishPreset.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Globalization;
-using System.Text;
-
 namespace TimeToTextLib.Presets;
 
 public class SpanishPreset : LanguagePreset
@@ -13,49 +9,24 @@ public class SpanishPreset : LanguagePreset
         var additionalMinutes = AdditionalMinutes(time.Minute);
         var hourForPrefix = minute >= 35 ? hour + 1 : hour;
 
-        var s = new StringBuilder($"{PrefixForHour(hourForPrefix)} ");
-
-        switch (minute)
+        var phrase = minute switch
         {
-            case 0:
-                s.Append(CultureInfo.InvariantCulture, $"{Hour(hour)} EN PUNTO");
-                break;
-            case 5:
-                s.Append(CultureInfo.InvariantCulture, $"{Hour(hour)} Y CINCO");
-                break;
-            case 10:
-                s.Append(CultureInfo.InvariantCulture, $"{Hour(hour)} Y DIEZ");
-                break;
-            case 15:
-                s.Append(CultureInfo.InvariantCulture, $"{Hour(hour)} Y CUARTO");
-                break;
-            case 20:
-                s.Append(CultureInfo.InvariantCulture, $"{Hour(hour)} Y VEINTE");
-                break;
-            case 25:
-                s.Append(CultureInfo.InvariantCulture, $"{Hour(hour)} Y VEINTICINCO");
-                break;
-            case 30:
-                s.Append(CultureInfo.InvariantCulture, $"{Hour(hour)} Y MEDIA");
-                break;
-            case 35:
-                s.Append(CultureInfo.InvariantCulture, $"{Hour(hour + 1)} MENOS VEINTICINCO");
-                break;
-            case 40:
-                s.Append(CultureInfo.InvariantCulture, $"{Hour(hour + 1)} MENOS VEINTE");
-                break;
-            case 45:
-                s.Append(CultureInfo.InvariantCulture, $"{Hour(hour + 1)} MENOS CUARTO");
-                break;
-            case 50:
-                s.Append(CultureInfo.InvariantCulture, $"{Hour(hour + 1)} MENOS DIEZ");
-                break;
-            case 55:
-                s.Append(CultureInfo.InvariantCulture, $"{Hour(hour + 1)} MENOS CINCO");
-                break;
-        }
+            0 => $"{Hour(hour)} EN PUNTO",
+            5 => $"{Hour(hour)} Y CINCO",
+            10 => $"{Hour(hour)} Y DIEZ",
+            15 => $"{Hour(hour)} Y CUARTO",
+            20 => $"{Hour(hour)} Y VEINTE",
+            25 => $"{Hour(hour)} Y VEINTICINCO",
+            30 => $"{Hour(hour)} Y MEDIA",
+            35 => $"{Hour(hour + 1)} MENOS VEINTICINCO",
+            40 => $"{Hour(hour + 1)} MENOS VEINTE",
+            45 => $"{Hour(hour + 1)} MENOS CUARTO",
+            50 => $"{Hour(hour + 1)} MENOS DIEZ",
+            55 => $"{Hour(hour + 1)} MENOS CINCO",
+            _ => throw new ArgumentOutOfRangeException(nameof(time)),
+        };
 
-        return new TimeToTextFormat { TimeAsText = s.ToString(), AdditionalMinutes = additionalMinutes };
+        return new TimeToTextFormat { TimeAsText = $"{PrefixForHour(hourForPrefix)} {phrase}", AdditionalMinutes = additionalMinutes };
     }
 
     protected override string[] Numbers =>

--- a/tests/TimeInWords.Tests/Controls/ColorFaderShould.cs
+++ b/tests/TimeInWords.Tests/Controls/ColorFaderShould.cs
@@ -15,9 +15,7 @@ public class ColorFaderShould
         var control = Substitute.For<IFadeableControl>();
         control.Foreground = new SolidColorBrush(startColor);
 
-        ColorFader.SetControlForeColor(control, endColor, 3, 0);
-
-        await Task.Delay(1000); // ensure we leave plenty of time to the fade to occur
+        await ColorFader.FadeForegroundAsync(control, endColor, intervals: 3, stepDelayMs: 0);
 
         (control.Foreground as SolidColorBrush)!.Color.Should().Be(endColor);
     }


### PR DESCRIPTION
## Summary

A handful of independent fixes from a code-review pass focused on complexity, readability, and maintainability. Each commit stands on its own; they are bundled because they share a theme rather than a feature.

- **Bitwise → logical operators** in `MainView.OnPointerMoved` movement detection (`f4aab6c`).
- **`Program.AppMain` argument parsing** no longer crashes on a 1-char `args[0]`, and dispatch is parsed once into a `StartupMode` enum instead of being woven through three branches (`a05bd05`).
- **`ColorFader`** is now cancellable and observable: `FadeForegroundAsync` returns a `Task`, accepts a `CancellationToken`, runs on the dispatcher, and `LedLetter` cancels-and-replaces the CTS on each `Active` flip so overlapping fades can no longer fight over `Foreground`. Also fixes a fire-and-forget `Task.Run` that swallowed exceptions (`ed2e323`).
- **`TimeGrid.GetBitmaskStrict`** replaces a hand-rolled, incomplete partial-match state machine (with a misleading comment) with row-wise `string.IndexOf` walking a `(row, col)` cursor (`52d2829`).
- **All 10 preset `Format` methods** (5 standard + 5 precise) converted to switch expressions sharing a single structural shape — minute-keyed switch builds a `phrase` string, prefix is prepended once. Drops `StringBuilder` + per-`Append` `CultureInfo.InvariantCulture` boilerplate; English/Dutch collapse `5 or 10`; previously-silent unreachable paths now throw `ArgumentOutOfRangeException` (`134d315`, `88169b0`).

## Test plan

- [ ] `dotnet build` (clean — 0 warnings, 0 errors)
- [ ] `dotnet run --project tests/TimeInWords.Tests --no-build` (34/34)
- [ ] `dotnet run --project tests/TimeToTextLib.Tests --no-build` (275/275, 10 generators skipped)
- [ ] `dotnet run --project tests/TextToTimeGridLib.Tests --no-build` (51/51, 1 generator skipped)
- [ ] Manual: launch the screensaver with no args, `/s`, `/c`, `/p`, and a 1-char arg — verify each behaves as documented.
- [ ] Manual: watch a few minute transitions to confirm the LED fade still looks right and that rapid changes don't leave fades fighting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)