### PR TITLE
Fix incorrect letter order in French precise grid 

### DIFF
--- a/src/TextToTimeGridLib/Grids/TimeGridFrenchPrecise.cs
+++ b/src/TextToTimeGridLib/Grids/TimeGridFrenchPrecise.cs
@@ -14,7 +14,7 @@ public class TimeGridFrenchPrecise : TimeGrid
         + '\n'
         + "NEUFDIXONZEDOUZEFG"
         + '\n'
-        + "HEURESJKMOINSLEFGB"
+        + "HEURESJKMOINSFGLEB"
         + '\n'
         + "TREIZEFQUATORZEBGJ"
         + '\n'


### PR DESCRIPTION
... to stop MOINS and LE being next to each other when lit.